### PR TITLE
add volume for config, limit logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,12 @@ services:
   ergo-node-zmqpub:
     container_name: ergo-node-zmqpub
     build: .
+    volumes:
+      - ./config.json:/app/config.json
     ports:
       - "9060:9060"
     restart: unless-stopped
+    logging:
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
- volume allows for  config to be updated without needing to rebuild container
- Logging limit saves space